### PR TITLE
[GH-3] Fix downloading remote_file connector-java

### DIFF
--- a/providers/j.rb
+++ b/providers/j.rb
@@ -35,7 +35,7 @@ action :create do
     source node['mysql_connector']['j']['url']
     checksum node['mysql_connector']['j']['checksum']
     mode 00644
-    action :create_if_missing
+    action :create
   end
 
   execute "mysql-connector-java-#{new_resource.path}" do


### PR DESCRIPTION
Replaced remote_file "mysql-connector-java.x.x.x.tar.gz"
    :create_if_missing by :create

Fixes the "taken no action" when the remote_file already exists,
while it should match the checksum to determine to download or not.
