### PR TITLE
Use the archive_url for all downloads

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,7 +1,6 @@
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 
-# rubocop:disable RegexpLiteral
 guard 'kitchen' do
   watch(%r{test/.+})
   watch(%r{^recipes/(.+)\.rb$})
@@ -11,4 +10,3 @@ guard 'kitchen' do
   watch(%r{^providers/(.+)\.rb})
   watch(%r{^resources/(.+)\.rb})
 end
-# rubocop:enable RegexpLiteral

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ version | Version of MySQL Connector/J to install | String | 5.1.36
 
 * `recipe[mysql_connector]` empty recipe for including LWRPs
 * `recipe[mysql_connector::j]` will install MySQL Connector/J from attribute
-* `recipe[mysql_connector::odbc_package]` will install MySQL Connector/ODBC from package.
 
 ## Usage
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,5 +18,4 @@ default['mysql_connector']['j']['install_paths'] = []
 default['mysql_connector']['j']['jar_file'] = "mysql-connector-java-#{node['mysql_connector']['j']['version']}-bin.jar"
 default['mysql_connector']['j']['tar_file'] = "mysql-connector-java-#{node['mysql_connector']['j']['version']}.tar.gz"
 
-default['mysql_connector']['j']['archive_url'] = "http://cdn.mysql.com/archives/mysql-connector-java-5.1/#{node['mysql_connector']['j']['tar_file']}"
-default['mysql_connector']['j']['url'] = "http://cdn.mysql.com/Downloads/Connector-J/#{node['mysql_connector']['j']['tar_file']}"
+default['mysql_connector']['j']['url'] = "http://cdn.mysql.com/archives/mysql-connector-java-5.1/#{node['mysql_connector']['j']['tar_file']}"

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,9 +8,8 @@ recipe 'mysql_connector', 'Empty recipe'
 recipe 'mysql_connector::j', 'Installs MySQL Connector/J via attribute.'
 recipe 'mysql_connector::odbc_package', 'Installs MySQL Connector/ODBC via package.'
 
-# %w{ ark }.each do |d|
-#  depends d
-# end
+# strip_components added
+depends 'ark', '>= 0.7.2'
 
 %w(amazon centos fedora redhat scientific ubuntu).each do |os|
   supports os

--- a/providers/j.rb
+++ b/providers/j.rb
@@ -20,24 +20,6 @@ action :create do
     action :create
   end
 
-  # BEGIN: This is workaround for remote_file not supporting 404's
-  # This is after various attempts at begin/rescue and requires ignore_failure above.
-  remote_file "#{Chef::Config[:file_cache_path]}/#{node['mysql_connector']['j']['tar_file']}-archive_url" do
-    source node['mysql_connector']['j']['archive_url']
-    checksum node['mysql_connector']['j']['checksum']
-    mode 00644
-    not_if "test -s #{Chef::Config[:file_cache_path]}/#{node['mysql_connector']['j']['tar_file']}"
-    action :create
-  end
-
-  execute 'mysql_connector_j_mv_archive_url' do
-    cwd Chef::Config[:file_cache_path]
-    command "mv #{node['mysql_connector']['j']['tar_file']}-archive_url #{node['mysql_connector']['j']['tar_file']}"
-    not_if "test -s #{Chef::Config[:file_cache_path]}/#{node['mysql_connector']['j']['tar_file']}"
-    action :run
-  end
-  # END: This is workaround for remote_file not supporting 404's
-
   execute "mysql-connector-java-#{new_resource.path}" do
     cwd Chef::Config[:file_cache_path]
     command "tar --strip-components=1 -xzf #{node['mysql_connector']['j']['tar_file']} -C #{new_resource.path} mysql-connector-java-#{node['mysql_connector']['j']['version']}/#{node['mysql_connector']['j']['jar_file']}"

--- a/providers/j.rb
+++ b/providers/j.rb
@@ -1,5 +1,5 @@
 action :create do
-  ark "mysql-connector-java" do
+  ark 'mysql-connector-java' do
     url node['mysql_connector']['j']['url']
     checksum node['mysql_connector']['j']['checksum']
     creates node['mysql_connector']['j']['jar_file']

--- a/providers/j.rb
+++ b/providers/j.rb
@@ -1,30 +1,10 @@
 action :create do
-  #
-  # MySQL Connector/J .tar.gz now contains extra directory and ark's
-  # :cherry_pick does not support --strip-components=1 currently
-  #
-  #  ark "mysql-connector-java" do
-  #    url node['mysql_connector']['j']['url']
-  #    checksum node['mysql_connector']['j']['checksum']
-  #    creates node['mysql_connector']['j']['jar_file']
-  #    path new_resource.path
-  #    action :cherry_pick
-  #  end
-  #
-
-  remote_file "#{Chef::Config[:file_cache_path]}/#{node['mysql_connector']['j']['tar_file']}" do
-    source node['mysql_connector']['j']['url']
+  ark "mysql-connector-java" do
+    url node['mysql_connector']['j']['url']
     checksum node['mysql_connector']['j']['checksum']
-    mode 00644
-    ignore_failure true
-    action :create
-  end
-
-  execute "mysql-connector-java-#{new_resource.path}" do
-    cwd Chef::Config[:file_cache_path]
-    command "tar --strip-components=1 -xzf #{node['mysql_connector']['j']['tar_file']} -C #{new_resource.path} mysql-connector-java-#{node['mysql_connector']['j']['version']}/#{node['mysql_connector']['j']['jar_file']}"
-    creates "#{new_resource.path}/#{node['mysql_connector']['j']['jar_file']}"
-    action :run
+    creates node['mysql_connector']['j']['jar_file']
+    path new_resource.path
+    action :cherry_pick
   end
 
   new_resource.updated_by_last_action(true)


### PR DESCRIPTION
https://github.com/bflad/chef-mysql_connector/blob/master/providers/j.rb

There seems to be lots going on here to get around the fact that the main download url changes, but why not just use the archive for everything. Even the newest tar is available there, so why not? :)
